### PR TITLE
Allow gaps

### DIFF
--- a/Bookish/Controllers/BookController.cs
+++ b/Bookish/Controllers/BookController.cs
@@ -23,7 +23,7 @@ public class BookController : Controller
     [HttpPost]
     public ActionResult AddBook(BookModel newBook)
     {
-        if (BookEditService.IsFormBlank(newBook))
+        if (BookSearchService.IsFormBlank(newBook))
         {
             return View();
         }

--- a/Bookish/Controllers/BookController.cs
+++ b/Bookish/Controllers/BookController.cs
@@ -23,8 +23,15 @@ public class BookController : Controller
     [HttpPost]
     public ActionResult AddBook(BookModel newBook)
     {
-        BookEditService.InsertBook(newBook);
-        return View(newBook);
+        if (BookEditService.IsFormBlank(newBook))
+        {
+            return View();
+        }
+        else
+        {
+            BookEditService.InsertBook(newBook);
+            return View(newBook);
+        }
     }
     
     [HttpGet]
@@ -38,7 +45,7 @@ public class BookController : Controller
     public ActionResult EditBook(BookModel replaceBook)
     {
         BookEditService.AlterBook(replaceBook.Id, replaceBook);
-        return RedirectToAction(nameof(Catalogue));
+        return RedirectToAction(nameof(SearchBooksResults));
     }
     
     [HttpPost]

--- a/Bookish/Controllers/BookController.cs
+++ b/Bookish/Controllers/BookController.cs
@@ -44,8 +44,15 @@ public class BookController : Controller
     [HttpPost]
     public ActionResult EditBook(BookModel replaceBook)
     {
-        BookEditService.AlterBook(replaceBook.Id, replaceBook);
-        return RedirectToAction(nameof(SearchBooksResults));
+        if (BookSearchService.IsFormBlank(replaceBook))
+        {
+            return View(replaceBook);
+        }
+        else
+        {
+            BookEditService.AlterBook(replaceBook.Id, replaceBook);
+            return RedirectToAction(nameof(Catalogue));
+        }
     }
     
     [HttpPost]

--- a/Bookish/Controllers/MemberController.cs
+++ b/Bookish/Controllers/MemberController.cs
@@ -23,8 +23,15 @@ public class MemberController : Controller
     [HttpPost]
     public ActionResult AddMember(MemberModel newMember)
     {
-        MemberEditService.InsertMember(newMember);
-        return View(newMember);
+        if (MemberSearchService.IsFormBlank(newMember))
+        {
+            return View();
+        }
+        else
+        {
+            MemberEditService.InsertMember(newMember);
+            return View(newMember);
+        }
     }
     
     public ActionResult EditMember(int id)

--- a/Bookish/Controllers/MemberController.cs
+++ b/Bookish/Controllers/MemberController.cs
@@ -34,6 +34,7 @@ public class MemberController : Controller
         }
     }
     
+    [HttpGet]
     public ActionResult EditMember(int id)
     {
         MemberModel updateMember = MemberEditService.GetMemberFromId(id);
@@ -43,8 +44,15 @@ public class MemberController : Controller
     [HttpPost]
     public ActionResult EditMember(MemberModel replaceMember)
     {
-        MemberEditService.AlterMember(replaceMember.Id, replaceMember);
-        return RedirectToAction(nameof(MemberList));
+        if (MemberSearchService.IsFormBlank(replaceMember))
+        {
+            return View(replaceMember);
+        }
+        else
+        {
+            MemberEditService.AlterMember(replaceMember.Id, replaceMember);
+            return RedirectToAction(nameof(MemberList));
+        }
     }
     
     [HttpPost]

--- a/Bookish/Services/BookEditService.cs
+++ b/Bookish/Services/BookEditService.cs
@@ -17,6 +17,13 @@ public class BookEditService
         
     public static void InsertBook(BookModel newBook)
     {
+        foreach (var property in typeof(BookModel).GetProperties())
+        {
+            if (property.GetValue(newBook) is null)
+            {
+                property.SetValue(newBook, " ");
+            }
+        }
         context.Books.Add(newBook);
         context.SaveChanges();
     }

--- a/Bookish/Services/BookEditService.cs
+++ b/Bookish/Services/BookEditService.cs
@@ -14,16 +14,22 @@ public class BookEditService
         BookModel book = context.Books.Single(b =>b.Id == id);
         return book;
     }
-        
-    public static void InsertBook(BookModel newBook)
+
+    public static BookModel nullConvert(BookModel book)
     {
         foreach (var property in typeof(BookModel).GetProperties())
         {
-            if (property.GetValue(newBook) is null)
+            if (property.GetValue(book) is null)
             {
-                property.SetValue(newBook, " ");
+                property.SetValue(book, " ");
             }
         }
+        return book;
+    }
+        
+    public static void InsertBook(BookModel newBook)
+    {
+        newBook = nullConvert(newBook);
         context.Books.Add(newBook);
         context.SaveChanges();
     }
@@ -38,6 +44,7 @@ public class BookEditService
                 property.SetValue(originalBook, property.GetValue(replaceBook));
             }
         }
+        originalBook = nullConvert(originalBook);
         context.SaveChanges();
     }
     

--- a/Bookish/Services/MemberEditService.cs
+++ b/Bookish/Services/MemberEditService.cs
@@ -14,16 +14,22 @@ public class MemberEditService
         MemberModel member = context.Members.Single(m =>m.Id == id);
         return member;
     }
-    
-    public static void InsertMember(MemberModel newMember)
+
+    public static MemberModel nullConvert(MemberModel member)
     {
         foreach (var property in typeof(MemberModel).GetProperties())
         {
-            if (property.GetValue(newMember) is null)
+            if (property.GetValue(member) is null)
             {
-                property.SetValue(newMember, " ");
+                property.SetValue(member, " ");
             }
         }
+        return member;
+    }
+    
+    public static void InsertMember(MemberModel newMember)
+    {
+        newMember = nullConvert(newMember);
         context.Members.Add(newMember);
         context.SaveChanges();
     }
@@ -38,6 +44,7 @@ public class MemberEditService
                 property.SetValue(originalMember, property.GetValue(replaceMember));
             }
         }
+        originalMember = nullConvert(originalMember);
         context.SaveChanges();
     }
     

--- a/Bookish/Services/MemberEditService.cs
+++ b/Bookish/Services/MemberEditService.cs
@@ -17,6 +17,13 @@ public class MemberEditService
     
     public static void InsertMember(MemberModel newMember)
     {
+        foreach (var property in typeof(MemberModel).GetProperties())
+        {
+            if (property.GetValue(newMember) is null)
+            {
+                property.SetValue(newMember, " ");
+            }
+        }
         context.Members.Add(newMember);
         context.SaveChanges();
     }

--- a/Bookish/Views/Book/EditBook.cshtml
+++ b/Bookish/Views/Book/EditBook.cshtml
@@ -5,6 +5,7 @@
 
 <div class="text-center">
     <h1 class="display-4">Edit a Book</h1>
+    <div> Book ID: @Model.Id </div>
 
     <div class="col">
         @using (Html.BeginForm("EditBook", "Book", FormMethod.Post))

--- a/Bookish/Views/Member/EditMember.cshtml
+++ b/Bookish/Views/Member/EditMember.cshtml
@@ -5,12 +5,7 @@
 
 <div class="text-center">
     <h1 class="display-4">Edit a Member</h1>
-    @if (Model != null)
-    {
-        <div class="alert alert-success" role="alert">
-            Successfully edited @Model.Name!
-        </div>
-    }
+    <div> Member ID: @Model.Id </div>
 
     <div class="col">
         @using (Html.BeginForm("EditMember", "Member", FormMethod.Post))


### PR DESCRIPTION
When adding a book/member or editing their information, fields can be left empty provided that at least one field is completed.
For now, this prevents the website from crashing; it could be refined into requiring certain fields (e.g. name of member, title of book) while allowing others to be left empty (e.g. if 'Book' had a property such as 'genre', this might be unknown).