### PR TITLE
Allow gaps

### DIFF
--- a/Bookish/Controllers/BookController.cs
+++ b/Bookish/Controllers/BookController.cs
@@ -25,13 +25,20 @@ public class BookController : Controller
     [HttpPost]
     public ActionResult AddBook(AddCopiesModel parameters)
     {
-        BookEditService.InsertBook(parameters.book);
-        var bookId = BookSearch.Search(parameters.book).First().Id;
-        for (int i = 0; i < parameters.numberOfCopies; i++)
+        if (BookEditService.IsFormBlank(parameters.book))
         {
-            BookCopyService.InsertBookCopy(bookId);
+            return View();
         }
-        return View(parameters.book);
+        else
+        {
+            BookEditService.InsertBook(parameters.book);
+            var bookId = BookSearch.Search(parameters.book).First().Id;
+            for (int i = 0; i < parameters.numberOfCopies; i++)
+            {
+                BookCopyService.InsertBookCopy(bookId);
+            }
+            return View(parameters.book);
+        }
     }
     
     [HttpGet]
@@ -45,7 +52,7 @@ public class BookController : Controller
     public ActionResult EditBook(BookModel replaceBook)
     {
         BookEditService.AlterBook(replaceBook.Id, replaceBook);
-        return RedirectToAction(nameof(Catalogue));
+        return RedirectToAction(nameof(SearchBooksResults));
     }
     
     [HttpPost]

--- a/Bookish/Controllers/BookController.cs
+++ b/Bookish/Controllers/BookController.cs
@@ -51,8 +51,15 @@ public class BookController : Controller
     [HttpPost]
     public ActionResult EditBook(BookModel replaceBook)
     {
-        BookEditService.AlterBook(replaceBook.Id, replaceBook);
-        return RedirectToAction(nameof(SearchBooksResults));
+        if (BookSearchService.IsFormBlank(replaceBook))
+        {
+            return View(replaceBook);
+        }
+        else
+        {
+            BookEditService.AlterBook(replaceBook.Id, replaceBook);
+            return RedirectToAction(nameof(Catalogue));
+        }
     }
     
     [HttpPost]

--- a/Bookish/Controllers/MemberController.cs
+++ b/Bookish/Controllers/MemberController.cs
@@ -46,8 +46,15 @@ public class MemberController : Controller
     [HttpPost]
     public ActionResult EditMember(MemberModel replaceMember)
     {
-        MemberEditService.AlterMember(replaceMember.Id, replaceMember);
-        return RedirectToAction(nameof(MemberList));
+        if (MemberSearchService.IsFormBlank(replaceMember))
+        {
+            return View(replaceMember);
+        }
+        else
+        {
+            MemberEditService.AlterMember(replaceMember.Id, replaceMember);
+            return RedirectToAction(nameof(MemberList));
+        }
     }
     
     [HttpPost]

--- a/Bookish/Controllers/MemberController.cs
+++ b/Bookish/Controllers/MemberController.cs
@@ -25,8 +25,15 @@ public class MemberController : Controller
     [HttpPost]
     public ActionResult AddMember(MemberModel newMember)
     {
-        MemberEditService.InsertMember(newMember);
-        return View(newMember);
+        if (MemberSearchService.IsFormBlank(newMember))
+        {
+            return View();
+        }
+        else
+        {
+            MemberEditService.InsertMember(newMember);
+            return View(newMember);
+        }
     }
     
     [HttpGet]

--- a/Bookish/Migrations/20220714111606_BookAndMemberProperties.Designer.cs
+++ b/Bookish/Migrations/20220714111606_BookAndMemberProperties.Designer.cs
@@ -4,6 +4,7 @@ using Bookish.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Bookish.Migrations
 {
     [DbContext(typeof(LibraryContext))]
-    partial class LibraryContextModelSnapshot : ModelSnapshot
+    [Migration("20220714111606_BookAndMemberProperties")]
+    partial class BookAndMemberProperties
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -36,7 +38,7 @@ namespace Bookish.Migrations
                     b.Property<int?>("BorrowerId")
                         .HasColumnType("int");
 
-                    b.Property<DateTime?>("DueDate")
+                    b.Property<DateTime>("DueDate")
                         .HasColumnType("datetime2");
 
                     b.HasKey("Id");
@@ -57,18 +59,22 @@ namespace Bookish.Migrations
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
 
                     b.Property<string>("Author")
+                        .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Genre")
+                        .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("ISBN")
+                        .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<int>("Publication_Year")
                         .HasColumnType("int");
 
                     b.Property<string>("Title")
+                        .IsRequired()
                         .HasColumnType("nvarchar(max)");
 
                     b.HasKey("Id");

--- a/Bookish/Migrations/20220714111606_BookAndMemberProperties.cs
+++ b/Bookish/Migrations/20220714111606_BookAndMemberProperties.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Bookish.Migrations
+{
+    public partial class BookAndMemberProperties : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DoB",
+                table: "Members",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<string>(
+                name: "Email",
+                table: "Members",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Mobile",
+                table: "Members",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Genre",
+                table: "Books",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ISBN",
+                table: "Books",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<int>(
+                name: "Publication_Year",
+                table: "Books",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DoB",
+                table: "Members");
+
+            migrationBuilder.DropColumn(
+                name: "Email",
+                table: "Members");
+
+            migrationBuilder.DropColumn(
+                name: "Mobile",
+                table: "Members");
+
+            migrationBuilder.DropColumn(
+                name: "Genre",
+                table: "Books");
+
+            migrationBuilder.DropColumn(
+                name: "ISBN",
+                table: "Books");
+
+            migrationBuilder.DropColumn(
+                name: "Publication_Year",
+                table: "Books");
+        }
+    }
+}

--- a/Bookish/Migrations/20220714112214_BookAndMemberPropertiesNullable.Designer.cs
+++ b/Bookish/Migrations/20220714112214_BookAndMemberPropertiesNullable.Designer.cs
@@ -4,6 +4,7 @@ using Bookish.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Bookish.Migrations
 {
     [DbContext(typeof(LibraryContext))]
-    partial class LibraryContextModelSnapshot : ModelSnapshot
+    [Migration("20220714112214_BookAndMemberPropertiesNullable")]
+    partial class BookAndMemberPropertiesNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -36,7 +38,7 @@ namespace Bookish.Migrations
                     b.Property<int?>("BorrowerId")
                         .HasColumnType("int");
 
-                    b.Property<DateTime?>("DueDate")
+                    b.Property<DateTime>("DueDate")
                         .HasColumnType("datetime2");
 
                     b.HasKey("Id");

--- a/Bookish/Migrations/20220714112214_BookAndMemberPropertiesNullable.cs
+++ b/Bookish/Migrations/20220714112214_BookAndMemberPropertiesNullable.cs
@@ -1,0 +1,87 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Bookish.Migrations
+{
+    public partial class BookAndMemberPropertiesNullable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Title",
+                table: "Books",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ISBN",
+                table: "Books",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Genre",
+                table: "Books",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Author",
+                table: "Books",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Title",
+                table: "Books",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ISBN",
+                table: "Books",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Genre",
+                table: "Books",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Author",
+                table: "Books",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+        }
+    }
+}

--- a/Bookish/Migrations/20220715111950_MemberNulls.Designer.cs
+++ b/Bookish/Migrations/20220715111950_MemberNulls.Designer.cs
@@ -4,6 +4,7 @@ using Bookish.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Bookish.Migrations
 {
     [DbContext(typeof(LibraryContext))]
-    partial class LibraryContextModelSnapshot : ModelSnapshot
+    [Migration("20220715111950_MemberNulls")]
+    partial class MemberNulls
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -36,7 +38,7 @@ namespace Bookish.Migrations
                     b.Property<int?>("BorrowerId")
                         .HasColumnType("int");
 
-                    b.Property<DateTime?>("DueDate")
+                    b.Property<DateTime>("DueDate")
                         .HasColumnType("datetime2");
 
                     b.HasKey("Id");
@@ -65,7 +67,7 @@ namespace Bookish.Migrations
                     b.Property<string>("ISBN")
                         .HasColumnType("nvarchar(max)");
 
-                    b.Property<int?>("Publication_Year")
+                    b.Property<int>("Publication_Year")
                         .HasColumnType("int");
 
                     b.Property<string>("Title")
@@ -84,7 +86,7 @@ namespace Bookish.Migrations
 
                     SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"), 1L, 1);
 
-                    b.Property<DateTime?>("DoB")
+                    b.Property<DateTime>("DoB")
                         .HasColumnType("datetime2");
 
                     b.Property<string>("Email")

--- a/Bookish/Migrations/20220715111950_MemberNulls.cs
+++ b/Bookish/Migrations/20220715111950_MemberNulls.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Bookish.Migrations
+{
+    public partial class MemberNulls : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Members",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Mobile",
+                table: "Members",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Email",
+                table: "Members",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Members",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Mobile",
+                table: "Members",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Email",
+                table: "Members",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+        }
+    }
+}

--- a/Bookish/Migrations/20220715113259_AllNulls.Designer.cs
+++ b/Bookish/Migrations/20220715113259_AllNulls.Designer.cs
@@ -4,6 +4,7 @@ using Bookish.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Bookish.Migrations
 {
     [DbContext(typeof(LibraryContext))]
-    partial class LibraryContextModelSnapshot : ModelSnapshot
+    [Migration("20220715113259_AllNulls")]
+    partial class AllNulls
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -36,7 +38,7 @@ namespace Bookish.Migrations
                     b.Property<int?>("BorrowerId")
                         .HasColumnType("int");
 
-                    b.Property<DateTime?>("DueDate")
+                    b.Property<DateTime>("DueDate")
                         .HasColumnType("datetime2");
 
                     b.HasKey("Id");

--- a/Bookish/Migrations/20220715113259_AllNulls.cs
+++ b/Bookish/Migrations/20220715113259_AllNulls.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Bookish.Migrations
+{
+    public partial class AllNulls : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Members",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Mobile",
+                table: "Members",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Email",
+                table: "Members",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "DoB",
+                table: "Members",
+                type: "datetime2",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Publication_Year",
+                table: "Books",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "Members",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Mobile",
+                table: "Members",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Email",
+                table: "Members",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "DoB",
+                table: "Members",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "datetime2",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "Publication_Year",
+                table: "Books",
+                type: "int",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+        }
+    }
+}

--- a/Bookish/Models/BookModel.cs
+++ b/Bookish/Models/BookModel.cs
@@ -5,7 +5,7 @@ public class BookModel
     public int Id { get; set; }
     public string? Author { get; set; }
     public string? Title { get; set; }
-    public int Publication_Year { get; set; }
+    public int? Publication_Year { get; set; }
     public string? ISBN { get; set; }
     public string? Genre { get; set; }
 

--- a/Bookish/Models/BookModel.cs
+++ b/Bookish/Models/BookModel.cs
@@ -3,7 +3,10 @@
 public class BookModel
 {
     public int Id { get; set; }
-    public string Author { get; set; }
-    public string Title { get; set; }
+    public string? Author { get; set; }
+    public string? Title { get; set; }
+    public int Publication_Year { get; set; }
+    public string? ISBN { get; set; }
+    public string? Genre { get; set; }
 
 }

--- a/Bookish/Models/MemberModel.cs
+++ b/Bookish/Models/MemberModel.cs
@@ -3,8 +3,8 @@
 public class MemberModel
 {
     public int Id { get; set; }
-    public string Name { get; set; }
-    public DateTime DoB { get; set; }
-    public string Email { get; set; }
-    public string Mobile { get; set; }
+    public string? Name { get; set; }
+    public DateTime? DoB { get; set; }
+    public string? Email { get; set; }
+    public string? Mobile { get; set; }
 }

--- a/Bookish/Models/MemberModel.cs
+++ b/Bookish/Models/MemberModel.cs
@@ -4,4 +4,7 @@ public class MemberModel
 {
     public int Id { get; set; }
     public string Name { get; set; }
+    public DateTime DoB { get; set; }
+    public string Email { get; set; }
+    public string Mobile { get; set; }
 }

--- a/Bookish/Services/BookEditService.cs
+++ b/Bookish/Services/BookEditService.cs
@@ -14,22 +14,9 @@ public class BookEditService
         BookModel book = context.Books.Single(b =>b.Id == id);
         return book;
     }
-
-    public static BookModel nullConvert(BookModel book)
-    {
-        foreach (var property in typeof(BookModel).GetProperties())
-        {
-            if (property.GetValue(book) is null)
-            {
-                property.SetValue(book, " ");
-            }
-        }
-        return book;
-    }
-        
+    
     public static void InsertBook(BookModel newBook)
     {
-        newBook = nullConvert(newBook);
         context.Books.Add(newBook);
         context.SaveChanges();
     }
@@ -44,7 +31,6 @@ public class BookEditService
                 property.SetValue(originalBook, property.GetValue(replaceBook));
             }
         }
-        originalBook = nullConvert(originalBook);
         context.SaveChanges();
     }
     

--- a/Bookish/Services/BookEditService.cs
+++ b/Bookish/Services/BookEditService.cs
@@ -17,6 +17,13 @@ public class BookEditService
         
     public static void InsertBook(BookModel newBook)
     {
+        foreach (var property in typeof(BookModel).GetProperties())
+        {
+            if (property.GetValue(newBook) is null)
+            {
+                property.SetValue(newBook, " ");
+            }
+        }
         context.Books.Add(newBook);
         context.SaveChanges();
     }

--- a/Bookish/Services/BookEditService.cs
+++ b/Bookish/Services/BookEditService.cs
@@ -14,16 +14,22 @@ public class BookEditService
         BookModel book = context.Books.Single(b =>b.Id == id);
         return book;
     }
-        
-    public static void InsertBook(BookModel newBook)
+
+    public static BookModel nullConvert(BookModel book)
     {
         foreach (var property in typeof(BookModel).GetProperties())
         {
-            if (property.GetValue(newBook) is null)
+            if (property.GetValue(book) is null)
             {
-                property.SetValue(newBook, " ");
+                property.SetValue(book, " ");
             }
         }
+        return book;
+    }
+        
+    public static void InsertBook(BookModel newBook)
+    {
+        newBook = nullConvert(newBook);
         context.Books.Add(newBook);
         context.SaveChanges();
     }
@@ -38,6 +44,7 @@ public class BookEditService
                 property.SetValue(originalBook, property.GetValue(replaceBook));
             }
         }
+        originalBook = nullConvert(originalBook);
         context.SaveChanges();
     }
     

--- a/Bookish/Services/MemberEditService.cs
+++ b/Bookish/Services/MemberEditService.cs
@@ -17,21 +17,8 @@ public class MemberEditService
         return member;
     }
 
-    public static MemberModel nullConvert(MemberModel member)
-    {
-        foreach (var property in typeof(MemberModel).GetProperties())
-        {
-            if (property.GetValue(member) is null)
-            {
-                property.SetValue(member, " ");
-            }
-        }
-        return member;
-    }
-    
     public static void InsertMember(MemberModel newMember)
     {
-        newMember = nullConvert(newMember);
         context.Members.Add(newMember);
         context.SaveChanges();
     }
@@ -46,7 +33,6 @@ public class MemberEditService
                 property.SetValue(originalMember, property.GetValue(replaceMember));
             }
         }
-        originalMember = nullConvert(originalMember);
         context.SaveChanges();
     }
     

--- a/Bookish/Services/MemberEditService.cs
+++ b/Bookish/Services/MemberEditService.cs
@@ -19,6 +19,13 @@ public class MemberEditService
     
     public static void InsertMember(MemberModel newMember)
     {
+        foreach (var property in typeof(MemberModel).GetProperties())
+        {
+            if (property.GetValue(newMember) is null)
+            {
+                property.SetValue(newMember, " ");
+            }
+        }
         context.Members.Add(newMember);
         context.SaveChanges();
     }

--- a/Bookish/Services/MemberEditService.cs
+++ b/Bookish/Services/MemberEditService.cs
@@ -16,16 +16,22 @@ public class MemberEditService
         MemberModel member = context.Members.Single(m =>m.Id == id);
         return member;
     }
-    
-    public static void InsertMember(MemberModel newMember)
+
+    public static MemberModel nullConvert(MemberModel member)
     {
         foreach (var property in typeof(MemberModel).GetProperties())
         {
-            if (property.GetValue(newMember) is null)
+            if (property.GetValue(member) is null)
             {
-                property.SetValue(newMember, " ");
+                property.SetValue(member, " ");
             }
         }
+        return member;
+    }
+    
+    public static void InsertMember(MemberModel newMember)
+    {
+        newMember = nullConvert(newMember);
         context.Members.Add(newMember);
         context.SaveChanges();
     }
@@ -40,6 +46,7 @@ public class MemberEditService
                 property.SetValue(originalMember, property.GetValue(replaceMember));
             }
         }
+        originalMember = nullConvert(originalMember);
         context.SaveChanges();
     }
     

--- a/Bookish/Views/Book/EditBook.cshtml
+++ b/Bookish/Views/Book/EditBook.cshtml
@@ -5,6 +5,7 @@
 
 <div class="text-center">
     <h1 class="display-4">Edit a Book</h1>
+    <div> Book ID: @Model.Id </div>
 
     <div class="col">
         @using (Html.BeginForm("EditBook", "Book", FormMethod.Post))

--- a/Bookish/Views/Member/EditMember.cshtml
+++ b/Bookish/Views/Member/EditMember.cshtml
@@ -5,6 +5,7 @@
 
 <div class="text-center">
     <h1 class="display-4">Edit a Member</h1>
+    <div> Member ID: @Model.Id </div>
 
     <div class="col">
         @using (Html.BeginForm("EditMember", "Member", FormMethod.Post))


### PR DESCRIPTION
Some minor changes to allow fields in book/member addition and editing forms to be left blank without breaking the website - this could be useful if e.g. the genre of a book is unknown. Currently any fields may be left blank provided that not all fields are blank; this could be later improved by forcing the user to complete certain fields (Book Title, Member Name) while allowing them to omit others.
Not a lot has really happened on this branch, but since properties have been added I think it would be useful to merge it back into main in order to be dealing with any side-effects of this.
The first few commits in this branch were partially undone by the final one, when I discovered a better way of dealing with null entries - this might make the edit history look a bit messy. I think ultimately I reversed all changes in EditServices and so only actually altered the [Book/Member]Model and the [Book/Member]Controller.